### PR TITLE
Minimum viable docker image build and push

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,33 @@
+name: Release Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      # TODO: Should be scoped to tag pushes eventually
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ngrok/ngrok-ingress-controller:latest

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - mschenck/12685/publish-docker-image
       # TODO: Should be scoped to tag pushes eventually
 
 jobs:


### PR DESCRIPTION
Very basic build and push (only tagging "latest").  This will build and push a new docker image on each merge to `main`.

References:
- [docker-login action](https://github.com/marketplace/actions/docker-login)
- [docker build and push action](https://github.com/marketplace/actions/build-and-push-docker-images)