### PR TITLE
minor helm clean up items so its useable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,8 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 .PHONY: deploy
 deploy: docker-build manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	helm upgrade ngrok-ingress-controller helm/ingress-controller --install \
-		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}"
+		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}" \
+		--set image.repository=$(IMG)
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ kubectl config set-context --current --namespace=ngrok-ingress-controller
 Create a secret with your API key and Auth Token
 
 ```bash
-kubectl create secret generic ngrok-ingress-controller-secrets \
+kubectl create secret generic ngrok-ingress-controller-credentials \
   --from-literal=api-key=$NGROK_API_KEY \
   --from-literal=auth-token=$NGROK_AUTHTOKEN
 ```

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     checksum/agent-config: {{ include (print $.Template.BasePath "/agent-config-cm.yaml") . | sha256sum }}
     checksum/controller-role: {{ include (print $.Template.BasePath "/role.yaml") . | sha256sum }}
     checksum/rbac: {{ include (print $.Template.BasePath "/controller-rbac.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 4 }}
+{{- end }}
 spec:
   replicas: {{.Values.replicaCount}}
   selector:

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -3,9 +3,9 @@
 replicaCount: 2
 
 image:
-  repository: ngrok-ingress-controller
+  repository: ngrok/ngrok-ingress-controller
   tag: latest
-  pullPolicy: Never
+  pullPolicy: IfNotPresent
 
 # The ingress class this controller will satisfy. If not specified, controller will match all
 # ingresses without ingress class annotation and ingresses of type ngrok


### PR DESCRIPTION
* Update the default image repository name to be what we want (once its public)
* Handle if pod annotations aren't set