### PR TITLE
Update helm install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Install via Helm:
 
 ```bash
 helm repo add ngrok https://ngrok.github.io/ngrok-ingress-controller
-helm install ngrok-ingress-controller ngrok/ingress-controller \
+helm install ngrok-ingress-controller ngrok/ngrok-ingress-controller \
   --namespace ngrok-ingress-controller \
   --create-namespace \
   --set apiKey=$(NGROK_API_KEY) \


### PR DESCRIPTION
It looks like the chart name is `ngrok-ingress-controller`. Updating the documentation to match.

```sh
$ helm search repo ngrok
NAME                          	CHART VERSION	APP VERSION	DESCRIPTION                                       
ngrok/ngrok-ingress-controller	0.1.2        	0.1.0      	A Kubernetes ingress controller built using ngrok.
```