### PR TITLE
Selectively run actions on fork

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -42,7 +42,10 @@ jobs:
     name: Release Images
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.repository == 'ngrok/ngrok-ingress-controller' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
       - main
-      - mschenck/12686/helm-release-workflow
     paths:
       - 'helm/ingress-controller/Chart.yaml'
 
 jobs:
   helm_release:
+    if: github.repository == 'ngrok/ngrok-ingress-controller' # Don't run on forks
     runs-on: ubuntu-latest
-
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This makes it so the release actions don't run on pushes to main for forks.