### PR TITLE
Add Issue and Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -1,0 +1,36 @@
+---
+name: Ngrok Ingress Controller Bug Report
+labels: ["bug", "area/controller", "needs-triage"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to fill out this bug report!
+
+      Note, you do not need to create an issue if you have a change ready to submit.
+      You can open a [pull request](https://github.com/ngrok/ngrok-ingress-controller/pulls) immediately instead.
+- type: textarea
+  attributes:
+    label: What happened
+    description: Describe what happened.
+    placeholder: >
+      Please provide the context in which the problem occurred and explain what happened
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What you think should happen instead
+    description: What do you think went wrong?
+    placeholder: >
+      Please explain why you think the behavior you observed is incorrect. It is extremely helpful
+      if you copy&paste the fragment of logs showing the exact error messages or wrong behavior.
+- type: textarea
+  attributes:
+    label: How to reproduce
+    description: What should we do to reproduce the problem?
+    placeholder: >
+      Please provide a reproducible step-by-step case of how to reproduce the problem as minimally and
+      precisely as possible. It will greatly help us in figuring out the root cause of the problem and fixing it.
+- type: markdown
+  attributes:
+    value: "Thank you for help in improving the Ngrok Ingress Controller!"

--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -1,5 +1,5 @@
 ---
-name: Ngrok Ingress Controller Bug Report
+name: ngrok Ingress Controller Bug Report
 labels: ["bug", "area/controller", "needs-triage"]
 body:
 - type: markdown
@@ -33,4 +33,4 @@ body:
       precisely as possible. It will greatly help us in figuring out the root cause of the problem and fixing it.
 - type: markdown
   attributes:
-    value: "Thank you for help in improving the Ngrok Ingress Controller!"
+    value: "Thank you for help in improving the ngrok Ingress Controller!"

--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -23,7 +23,7 @@ body:
     description: What do you think went wrong?
     placeholder: >
       Please explain why you think the behavior you observed is incorrect. It is extremely helpful
-      if you copy&paste the fragment of logs showing the exact error messages or wrong behavior.
+      if you copy & paste the fragment of logs showing the exact error messages or wrong behavior.
 - type: textarea
   attributes:
     label: How to reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,5 @@
 ---
-name: Ngrok Ingress Controller Feature Request
+name: ngrok Ingress Controller Feature Request
 description: Suggest an idea for this project
 labels: ["enhancement", "needs-triage"]
 body:
@@ -8,7 +8,7 @@ body:
     value: |
       Thanks for taking the time to fill out this feature request!
 
-      We really appreciate the community efforts to improve the Ngrok Ingress Controller.
+      We really appreciate the community efforts to improve the ngrok Ingress Controller.
 
 - type: textarea
   attributes:
@@ -27,4 +27,4 @@ body:
     description: Are there any related issues?
 - type: markdown
   attributes:
-    value: "Thank you for help in improving the Ngrok Ingress Controller!"
+    value: "Thank you for help in improving the ngrok Ingress Controller!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,30 @@
+---
+name: Ngrok Ingress Controller Feature Request
+description: Suggest an idea for this project
+labels: ["enhancement", "needs-triage"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to fill out this feature request!
+
+      We really appreciate the community efforts to improve the Ngrok Ingress Controller.
+
+- type: textarea
+  attributes:
+    label: Description
+    description: A short description of the feature request
+- type: textarea
+  attributes:
+    label: Use Case
+    description: What is the use case for this feature?
+    placeholder: >
+      Rather than telling us how you might implement this feature, try to take a step
+      back and explain what you are trying to achieve.
+- type: textarea
+  attributes:
+    label: Related issues
+    description: Are there any related issues?
+- type: markdown
+  attributes:
+    value: "Thank you for help in improving the Ngrok Ingress Controller!"

--- a/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
@@ -43,7 +43,7 @@ body:
     description: What do you think went wrong?
     placeholder: >
       Please explain why you think the behavior you observed is incorrect. It is extremely helpful
-      if you copy&paste the fragment of logs showing the exact error messages or wrong behavior.
+      if you copy & paste the fragment of logs showing the exact error messages or wrong behavior.
 - type: textarea
   attributes:
     label: How to reproduce

--- a/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
@@ -1,0 +1,56 @@
+---
+name: Ngrok Ingress Controller Helm Chart Bug Report
+labels: ["bug", "area/helm-chart", "needs-triage"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to fill out this bug report!
+
+      Note, you do not need to create an issue if you have a change ready to submit.
+      You can open a [pull request](https://github.com/ngrok/ngrok-ingress-controller/pulls) immediately instead.
+- type: input
+  attributes:
+    label: Kubernetes Version
+    description: Which Kubernetes Version do you use?
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Helm Chart Version
+    description: Which version of the Helm chart do you use?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Helm Chart configuration
+    description: Additional description of your Helm Chart configuration.
+    placeholder: >
+      Enter any relevant details of your Helm Chart configuration. Maybe you can
+      paste your `values.yaml` or important parts of it here? Make sure to surround the code
+      you paste with ``` ```.
+- type: textarea
+  attributes:
+    label: What happened
+    description: Describe what happened.
+    placeholder: >
+      Please provide the context in which the problem occurred and explain what happened
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What you think should happen instead
+    description: What do you think went wrong?
+    placeholder: >
+      Please explain why you think the behavior you observed is incorrect. It is extremely helpful
+      if you copy&paste the fragment of logs showing the exact error messages or wrong behavior.
+- type: textarea
+  attributes:
+    label: How to reproduce
+    description: What should we do to reproduce the problem?
+    placeholder: >
+      Please provide a reproducible step-by-step case of how to reproduce the problem as minimally and
+      precisely as possible. It will greatly help us in figuring out the root cause of the problem and fixing it.
+- type: markdown
+  attributes:
+    value: "Thank you for help in improving the Ngrok Ingress Controller Helm Chart!"

--- a/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
@@ -1,5 +1,5 @@
 ---
-name: Ngrok Ingress Controller Helm Chart Bug Report
+name: ngrok Ingress Controller Helm Chart Bug Report
 labels: ["bug", "area/helm-chart", "needs-triage"]
 body:
 - type: markdown
@@ -53,4 +53,4 @@ body:
       precisely as possible. It will greatly help us in figuring out the root cause of the problem and fixing it.
 - type: markdown
   attributes:
-    value: "Thank you for help in improving the Ngrok Ingress Controller Helm Chart!"
+    value: "Thank you for help in improving the ngrok Ingress Controller Helm Chart!"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Thank you for contributing! Please make sure that your code changes
+are covered with tests. In case of new features or big changes remember
+to adjust the documentation.
+
+In case of an existing issue, reference it using one of the following:
+
+closes: #ISSUE
+related: #ISSUE
+
+How to write a good git commit message:
+http://chris.beams.io/posts/git-commit/
+-->
+
+## What
+*Describe what the change is solving*
+
+## How
+*Describe the solution*
+
+## Breaking Changes
+*Are there any breaking changes in this PR?*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://ngrok.com">
-    <img src="docs/images/ngrok-blue-lrg.png" alt="Ngrok Logo" width="500" url="https://ngrok.com" />
+    <img src="docs/images/ngrok-blue-lrg.png" alt="ngrok Logo" width="500" url="https://ngrok.com" />
   </a>
   <a href="https://kubernetes.io/">
   <img src="docs/images/Kubernetes-icon-color.svg.png" alt="Kubernetes logo" width="250" />
@@ -30,9 +30,9 @@
 
 
 
-# Ngrok Ingress Controller
+# ngrok Ingress Controller
 
-This is a general purpose [kubernetes ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) provides to workloads running in a kubernetes cluster with a public URL via [ngrok](https://ngrok.com/). It dynamically provisions and deprovisions multiple highly available Ngrok [tunnels](https://ngrok.com/docs/secure-tunnels#labeled-tunnels) and [edges](https://ngrok.com/docs/secure-tunnels#integrating-with-cloud-edge) as ingress resources are created and deleted. Take a guided tour through the architecture [here](https://s.icepanel.io/tPjIPc8Ifg/kj7w).
+This is a general purpose [kubernetes ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) provides to workloads running in a kubernetes cluster with a public URL via [ngrok](https://ngrok.com/). It dynamically provisions and deprovisions multiple highly available ngrok [tunnels](https://ngrok.com/docs/secure-tunnels#labeled-tunnels) and [edges](https://ngrok.com/docs/secure-tunnels#integrating-with-cloud-edge) as ingress resources are created and deleted. Take a guided tour through the architecture [here](https://s.icepanel.io/tPjIPc8Ifg/kj7w).
 
 ## Features and Alpha Status
 
@@ -40,20 +40,20 @@ This project is currently in alpha status. It is not yet recommended for product
 * Create, update, and delete ingress objects and have their corresponding tunnels and edges to be updated in response.
 * Install via Helm
 * Supports multiple routes, BUT ONLY ONE host per ingress object at this time.
-* MUST have a pro account to use this controller. The controller will not work with a free account right now as it requires the usage of Ngrok Edges.
+* MUST have a pro account to use this controller. The controller will not work with a free account right now as it requires the usage of ngrok Edges.
 
 ### Looking Forward
 
 An official roadmap is coming soon. In the meantime, here are some of the features we are working on:
 * Stability and HA testing and improvements. Especially during ingress updates, or controller rollouts.
 * Support for multiple hosts per ingress object.
-* Support for all of Ngrok's Edge Modules such as [Oauth](https://ngrok.com/docs/api#api-edge-route-o-auth-module)
+* Support for all of ngrok's Edge Modules such as [Oauth](https://ngrok.com/docs/api#api-edge-route-o-auth-module)
 * Free tier support
 
 
 ## Getting Started
 
-Get your [Ngrok API Key](https://ngrok.com/docs/api#authentication) and [Ngrok Auth Token](https://dashboard.ngrok.com/) and export them as environment variables
+Get your [ngrok API Key](https://ngrok.com/docs/api#authentication) and [ngrok Auth Token](https://dashboard.ngrok.com/) and export them as environment variables
 
   ```bash
 export NGROK_API_KEY=<YOUR Secret API KEY>

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -1,4 +1,4 @@
-# Ngrok Ingress Controller
+# ngrok Ingress Controller
 
 This is the helm chart to install the ngrok ingress controller
 

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -126,7 +126,7 @@ func (irec *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(irec)
 }
 
-// Converts a k8s Ingress Rule to and Ngrok Route configuration.
+// Converts a k8s Ingress Rule to and ngrok Route configuration.
 func (irec *IngressReconciler) routesPlanner(ctx context.Context, rule netv1.IngressRuleValue, ingressName, namespace string, annotations map[string]string) ([]ngrokapidriver.Route, error) {
 	var matchType string
 	var ngrokRoutes []ngrokapidriver.Route
@@ -166,7 +166,7 @@ func (irec *IngressReconciler) routesPlanner(ctx context.Context, rule netv1.Ing
 	return ngrokRoutes, nil
 }
 
-// Converts a k8s ingress object into an Ngrok Edge with all its configurations and sub-resources
+// Converts a k8s ingress object into an ngrok Edge with all its configurations and sub-resources
 // TODO: Support multiple Rules per Ingress
 func (irec *IngressReconciler) ingressToEdge(ctx context.Context, ingress *netv1.Ingress) (*ngrokapidriver.Edge, error) {
 	annotations := ingress.ObjectMeta.GetAnnotations()

--- a/internal/controllers/main.go
+++ b/internal/controllers/main.go
@@ -67,7 +67,7 @@ func matchesIngressClass(ctx context.Context, c client.Client, ingress *netv1.In
 		if ingress.Spec.IngressClassName == nil || ingress.Spec.IngressClassName == &ngrokClass.Name {
 			return true, nil
 		}
-		ctrl.LoggerFrom(ctx).Info(fmt.Sprintf("Ngrok is the default Ingress class  but this ingress object's ingress class doesn't match: %s\n", *ingress.Spec.IngressClassName), "controller", controllerName)
+		ctrl.LoggerFrom(ctx).Info(fmt.Sprintf("ngrok is the default Ingress class  but this ingress object's ingress class doesn't match: %s\n", *ingress.Spec.IngressClassName), "controller", controllerName)
 		return false, nil
 	}
 
@@ -193,7 +193,7 @@ func validateIngress(ctx context.Context, ingress *netv1.Ingress) error {
 	return nil
 }
 
-// Generates a labels map for matching Ngrok Routes to Agent Tunnels
+// Generates a labels map for matching ngrok Routes to Agent Tunnels
 func backendToLabelMap(backend netv1.IngressBackend, ingressName, namespace string) map[string]string {
 	return map[string]string{
 		"k8s.ngrok.com/ingress-name":      ingressName,

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -127,7 +127,7 @@ func (trec *TunnelController) Start(ctx context.Context) error {
 	return trec.Controller.Start(ctx)
 }
 
-// Converts a k8s Ingress Rule to and Ngrok Agent Tunnel configuration.
+// Converts a k8s Ingress Rule to and ngrok Agent Tunnel configuration.
 func tunnelsPlanner(rule netv1.IngressRuleValue, ingressName, namespace string) []agentapiclient.TunnelsAPIBody {
 	var agentTunnels []agentapiclient.TunnelsAPIBody
 
@@ -153,7 +153,7 @@ func tunnelsPlanner(rule netv1.IngressRuleValue, ingressName, namespace string) 
 	return agentTunnels
 }
 
-// Converts a k8s ingress object into a slice of Ngrok Agent Tunnels
+// Converts a k8s ingress object into a slice of ngrok Agent Tunnels
 // TODO: Support multiple Rules per Ingress
 func ingressToTunnels(ingress *netv1.Ingress) []agentapiclient.TunnelsAPIBody {
 	ingressRule := ingress.Spec.Rules[0]

--- a/pkg/ngrokapidriver/driver.go
+++ b/pkg/ngrokapidriver/driver.go
@@ -14,7 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// NgrkAPIDriver is an interface for managing Ngrok API resources
+// NgrkAPIDriver is an interface for managing ngrok API resources
 type NgrokAPIDriver interface {
 	FindEdge(ctx context.Context, id string) (*ngrok.HTTPSEdge, error)
 	CreateEdge(ctx context.Context, e *Edge) (*ngrok.HTTPSEdge, error)


### PR DESCRIPTION
## What

Add Issue and Pull Request Templates

## Why

Will help us better triage issues by providing community members and ourselves templates for creating issues. We can still fall back to "Blank" issues if we need to.