### PR TITLE
fix: Add description to issue templates so they are valid

### DIFF
--- a/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/controller_bug_report.yaml
@@ -1,5 +1,6 @@
 ---
 name: ngrok Ingress Controller Bug Report
+description: Report an issue in the ngrok Ingress Controller
 labels: ["bug", "area/controller", "needs-triage"]
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/helm_bug_report.yaml
@@ -1,5 +1,6 @@
 ---
 name: ngrok Ingress Controller Helm Chart Bug Report
+description: Report an issue in the ngrok Ingress Controller Helm Chart
 labels: ["bug", "area/helm-chart", "needs-triage"]
 body:
 - type: markdown


### PR DESCRIPTION
## What

Fixes 2 of the issue templates that aren't valid because they are missing a `description`.

