### PR TITLE
Add unit tests for ingress controller & tunnel controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.0
 	github.com/ngrok/ngrok-api-go/v5 v5.0.0
 	github.com/spf13/cobra v1.2.1
+	github.com/stretchr/testify v1.7.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
@@ -87,7 +88,6 @@ require (
 	github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/ulikunitz/xz v0.5.5 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/yujunz/go-getter v1.4.1-lite // indirect

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -169,6 +169,16 @@ func (irec *IngressReconciler) routesPlanner(ctx context.Context, rule netv1.Ing
 // Converts a k8s ingress object into an ngrok Edge with all its configurations and sub-resources
 // TODO: Support multiple Rules per Ingress
 func (irec *IngressReconciler) ingressToEdge(ctx context.Context, ingress *netv1.Ingress) (*ngrokapidriver.Edge, error) {
+	if ingress == nil {
+		return nil, nil
+	}
+
+	// An ingress with no rules sends all traffic to a single default backend(.spec.defaultBackend)
+	// and must be specified. TODO: Implement this.
+	if len(ingress.Spec.Rules) == 0 {
+		return nil, nil
+	}
+
 	annotations := ingress.ObjectMeta.GetAnnotations()
 	ingressRule := ingress.Spec.Rules[0]
 

--- a/internal/controllers/ingress_controller_test.go
+++ b/internal/controllers/ingress_controller_test.go
@@ -1,0 +1,110 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ngrok/ngrok-ingress-controller/pkg/ngrokapidriver"
+	"github.com/stretchr/testify/assert"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngressReconcilerIngressToEdge(t *testing.T) {
+	prefix := netv1.PathTypePrefix
+	testCases := []struct {
+		testName string
+		ingress  *netv1.Ingress
+		edge     *ngrokapidriver.Edge
+		err      error
+	}{
+		{
+			testName: "Returns a nil edge when ingress is nil",
+			ingress:  nil,
+			edge:     nil,
+		},
+		{
+			testName: "Returns a nil edge when ingress has no rules",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{},
+				},
+			},
+			edge: nil,
+		},
+		{
+			testName: "",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "test-namespace",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							Host: "my-test-tunnel.ngrok.io",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path:     "/",
+											PathType: &prefix,
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: netv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			edge: &ngrokapidriver.Edge{
+				Hostport: "my-test-tunnel.ngrok.io:443",
+				Id:       "",
+				Routes: []ngrokapidriver.Route{
+					{
+						Id:        "",
+						Match:     "/",
+						MatchType: "path_prefix",
+						Labels: map[string]string{
+							"k8s.ngrok.com/ingress-name":      "test-ingress",
+							"k8s.ngrok.com/ingress-namespace": "test-namespace",
+							"k8s.ngrok.com/port":              "8080",
+							"k8s.ngrok.com/service":           "test-service",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		irec := IngressReconciler{}
+		edge, err := irec.ingressToEdge(context.Background(), testCase.ingress)
+
+		if testCase.err != nil {
+			assert.ErrorIs(t, err, testCase.err)
+			continue
+		}
+		assert.NoError(t, err)
+
+		if testCase.edge == nil {
+			assert.Nil(t, edge)
+			continue
+		}
+
+		assert.Equal(t, testCase.edge.Hostport, edge.Hostport, "Hostport does not match expected value")
+		assert.Equal(t, testCase.edge.Id, edge.Id, "ID does not match expected value")
+		assert.ElementsMatch(t, testCase.edge.Routes, edge.Routes)
+	}
+}

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -156,6 +156,9 @@ func tunnelsPlanner(rule netv1.IngressRuleValue, ingressName, namespace string) 
 // Converts a k8s ingress object into a slice of ngrok Agent Tunnels
 // TODO: Support multiple Rules per Ingress
 func ingressToTunnels(ingress *netv1.Ingress) []agentapiclient.TunnelsAPIBody {
+	if ingress == nil || len(ingress.Spec.Rules) == 0 {
+		return []agentapiclient.TunnelsAPIBody{}
+	}
 	ingressRule := ingress.Spec.Rules[0]
 
 	tunnels := tunnelsPlanner(ingressRule.IngressRuleValue, ingress.Name, ingress.Namespace)

--- a/internal/controllers/tunnel_controller_test.go
+++ b/internal/controllers/tunnel_controller_test.go
@@ -1,0 +1,94 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/ngrok/ngrok-ingress-controller/pkg/agentapiclient"
+	"github.com/stretchr/testify/assert"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngressToTunnels(t *testing.T) {
+
+	testCases := []struct {
+		testName string
+		ingress  *netv1.Ingress
+		tunnels  []agentapiclient.TunnelsAPIBody
+	}{
+		{
+			testName: "Returns empty list when ingress is nil",
+			ingress:  nil,
+			tunnels:  []agentapiclient.TunnelsAPIBody{},
+		},
+		{
+			testName: "Returns empty list when ingress has no rules",
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-ingress",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{},
+				},
+			},
+			tunnels: []agentapiclient.TunnelsAPIBody{},
+		},
+		{
+			ingress: &netv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ingress",
+					Namespace: "test-namespace",
+				},
+				Spec: netv1.IngressSpec{
+					Rules: []netv1.IngressRule{
+						{
+							Host: "my-test-tunnel.ngrok.io",
+							IngressRuleValue: netv1.IngressRuleValue{
+								HTTP: &netv1.HTTPIngressRuleValue{
+									Paths: []netv1.HTTPIngressPath{
+										{
+											Path: "/",
+											Backend: netv1.IngressBackend{
+												Service: &netv1.IngressServiceBackend{
+													Name: "test-service",
+													Port: netv1.ServiceBackendPort{
+														Number: 8080,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tunnels: []agentapiclient.TunnelsAPIBody{
+				{
+					Addr:      "test-service.test-namespace.svc.cluster.local:8080",
+					Name:      "test-ingress-test-namespace-test-service-8080--",
+					SubDomain: "",
+					Labels: []string{
+						"k8s.ngrok.com/ingress-name=test-ingress",
+						"k8s.ngrok.com/ingress-namespace=test-namespace",
+						"k8s.ngrok.com/service=test-service",
+						"k8s.ngrok.com/port=8080",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		tunnels := ingressToTunnels(test.ingress)
+
+		assert.Equal(t, len(tunnels), len(test.tunnels))
+		for i := 0; i < len(tunnels); i++ {
+			assert.Equal(t, tunnels[i].Name, test.tunnels[i].Name)
+			assert.Equal(t, tunnels[i].Addr, test.tunnels[i].Addr)
+			assert.Equal(t, tunnels[i].SubDomain, test.tunnels[i].SubDomain)
+			assert.ElementsMatch(t, tunnels[i].Labels, test.tunnels[i].Labels)
+		}
+	}
+}


### PR DESCRIPTION
Related: #39 

## What

This change adds in some tests for both the ingress controller and tunnel controller to validate the edge and tunnel API objects we are creating.

## How

Test that given certain ingress objects, they return the respective edge and tunnel API objects.

