### PR TITLE
Implemented two predicate filters per reconciler

### DIFF
--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- if .Values.podAnnotations }}
           {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
+        prometheus.io/path: /metrics
+        prometheus.io/port: '8080'
+        prometheus.io/scrape: 'true'
       labels:
         app: ngrok-ingress-controller
     spec:
@@ -38,7 +41,7 @@ spec:
         - /manager
         args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         {{- if .Values.region }}
         - --region={{ .Values.region}}

--- a/internal/controllers/ingress_controller.go
+++ b/internal/controllers/ingress_controller.go
@@ -13,6 +13,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -123,6 +125,18 @@ func (irec *IngressReconciler) CreateIngress(ctx context.Context, edge *ngrokapi
 func (irec *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&netv1.Ingress{}).
+		WithEventFilter(predicate.Funcs{
+			DeleteFunc: func(de event.DeleteEvent) bool {
+				// Ignore deletes.  Since we leverage a finalizer, we initiate "deletion"
+				// when an Update Event includes a metadata.deletionTimestamp
+				return false
+			},
+			UpdateFunc: func(ue event.UpdateEvent) bool {
+				// No change to spec, so we can ignore.  This does not filter out updates
+				// that set metadata.deletionTimestamp, so this won't undermine finalizer.
+				return ue.ObjectNew.GetGeneration() != ue.ObjectOld.GetGeneration()
+			},
+		}).
 		Complete(irec)
 }
 


### PR DESCRIPTION
- Implemented two predicate filters per reconciler
- Enabled prometheus scraping

<!-- Thank you for contributing! Please make sure that your code changes
are covered with tests. In case of new features or big changes remember
to adjust the documentation.

In case of an existing issue, reference it using one of the following:

closes: #37
related: #37

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## What
*Describe what the change is solving*
1. Ignores Ingress delete events as we leverage a finalizer and handle delete operations when the `metadata.deletionTimestamp` is applied to the object
2. Ignores update events with no changes to the Ingress object's Spec (no new revision)
3. Added prometheus scraping to the helm chart, which helped visualize reconciliation events

## How
*Describe the solution*
This change is leveraging predicate filters to avoid taking action when no action is necessary.
These two blog posts talk about this:
1. [Using Event Filters with Kubebuilder - Part 1](https://stuartleeks.com/posts/kubebuilder-event-filters-part-1-delete/)
1. [Using Event Filters with Kubebuilder - Part 2](https://stuartleeks.com/posts/kubebuilder-event-filters-part-2-update/)

See also [finalizers](https://kubernetes.io/docs/concepts/overview/working-with-objects/finalizers/#how-finalizers-work)

## Breaking Changes
*Are there any breaking changes in this PR?*
No