### PR TITLE
Trigger update when annotations change

### DIFF
--- a/internal/controllers/predicate_filters.go
+++ b/internal/controllers/predicate_filters.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// common delete func predicate filter
+func deleteFuncPredicateFilter(de event.DeleteEvent) bool {
+	// Ignore deletes.  Since we leverage a finalizer, we initiate "deletion"
+	// when an Update Event includes a metadata.deletionTimestamp
+	return true
+}
+
+// common update func predicate filter
+func updateFuncPredicateFilter(ue event.UpdateEvent) bool {
+	// First check if there are any annotations present that aren't in the old version
+	oldAnnotations := ue.ObjectOld.GetAnnotations()
+	for newKey, newValue := range ue.ObjectNew.GetAnnotations() {
+		if oldAnnotations[newKey] != newValue {
+			return true
+		}
+	}
+	// No change to spec, so we can ignore.  This does not filter out updates
+	// that set metadata.deletionTimestamp, so this won't undermine finalizer.
+	return ue.ObjectNew.GetGeneration() != ue.ObjectOld.GetGeneration()
+}
+
+var commonPredicateFilters = predicate.Funcs{
+	DeleteFunc: deleteFuncPredicateFilter,
+	UpdateFunc: updateFuncPredicateFilter,
+}

--- a/internal/controllers/tunnel_controller.go
+++ b/internal/controllers/tunnel_controller.go
@@ -14,10 +14,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -89,25 +87,12 @@ func (trec *TunnelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // Create a new Controller that watches Ingress objects.
 // Add it to our manager.
 func (trec *TunnelReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	predicateFilters := predicate.Funcs{
-		DeleteFunc: func(de event.DeleteEvent) bool {
-			// Ignore deletes.  Since we leverage a finalizer, we initiate "deletion"
-			// when an Update Event includes a metadata.deletionTimestamp
-			return false
-		},
-		UpdateFunc: func(ue event.UpdateEvent) bool {
-			// No change to spec, so we can ignore.  This does not filter out updates
-			// that set metadata.deletionTimestamp, so this won't undermine finalizer.
-			return ue.ObjectNew.GetGeneration() != ue.ObjectOld.GetGeneration()
-		},
-	}
-
 	tCont, err := NewTunnelControllerNew("tunnel-controller", mgr, trec)
 	if err != nil {
 		return err
 	}
 
-	if err := tCont.Watch(&source.Kind{Type: &netv1.Ingress{}}, &handler.EnqueueRequestForObject{}, predicateFilters); err != nil {
+	if err := tCont.Watch(&source.Kind{Type: &netv1.Ingress{}}, &handler.EnqueueRequestForObject{}, commonPredicateFilters); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What

Updates predicate filters so we also capture changes to annotations

## How

Annotations are outside of the `Ingress`'s `spec` field so they don't trigger a change in the generation. This compares the old annotations to the new annotations to figure out if we need to do a reconcile.

## Breaking Changes
No
