### PR TITLE
Add Helm Common Values

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -87,7 +87,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: `ngrok-ingress-controller-${tag}`,
-              name: tag,
+              name: `ngrok-ingress-controller-${tag}`,
               body: `${tag}`,
               draft: false,
               prerelease: false

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ KUSTOMIZE = go run sigs.k8s.io/kustomize/kustomize/v3
 
 ENVTEST = go run sigs.k8s.io/controller-runtime/tools/setup-envtest
 
+HELM_CHART_DIR = ./helm/ingress-controller
+
 # Targets
 
 .PHONY: all
@@ -107,7 +109,7 @@ uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube
 
 .PHONY: deploy
 deploy: docker-build manifests ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	helm upgrade ngrok-ingress-controller helm/ingress-controller --install \
+	helm upgrade ngrok-ingress-controller $(HELM_CHART_DIR) --install \
 		--namespace ngrok-ingress-controller \
 		--create-namespace \
 		--set podAnnotations."k8s\.ngrok\.com/test"="\{\"env\": \"local\"\}" \
@@ -121,9 +123,14 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: helm-lint
 helm-lint: ## Lint the helm chart
-	helm lint helm/ingress-controller
+	helm lint $(HELM_CHART_DIR)
 
 .PHONY: helm-test
 helm-test: ## Run helm unittest plugin
 	./scripts/helm-setup.sh
-	cd helm/ingress-controller && helm unittest --helm3 .
+	helm unittest --helm3 $(HELM_CHART_DIR)
+
+.PHONY: helm-update-snapshots
+helm-update-snapshots: ## Update helm unittest snapshots
+	./scripts/helm-setup.sh
+	helm unittest --helm3 -u $(HELM_CHART_DIR)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ data:
 ## How to Configure the Agent
 
 > Warning: This will be deprecated soon when moving to the new lib-ngrok library
-* assumes configs will be in a config map named `ngrok-ingress-controller-agent-cm` in the same namespace
+* assumes configs will be in a config map named `{{ include "ngrok-ingress-controller.fullname" . }}-agent-cm` in the same namespace
 * setup automatically via helm. Values and config map name can be configured in the future via helm
 * subset of these that should be configurable https://ngrok.com/docs/ngrok-agent/config#config-full-example
 * example config map showing all optional values with their defaults.
@@ -135,7 +135,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ngrok-ingress-controller-agent-cm
+  name: {{ include "ngrok-ingress-controller.fullname" . }}-agent-cm
   namespace: ngrok-ingress-controller
 data:
   LOG: stdout

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -54,10 +54,10 @@ func main() {
 
 type managerOpts struct {
 	// flags
-	metricsAddr          string
-	enableLeaderElection bool
-	probeAddr            string
-	zapOpts              *zap.Options
+	metricsAddr string
+	electionID  string
+	probeAddr   string
+	zapOpts     *zap.Options
 
 	// env vars
 	namespace   string
@@ -77,7 +77,7 @@ func cmd() *cobra.Command {
 
 	c.Flags().StringVar(&opts.metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to")
 	c.Flags().StringVar(&opts.probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	c.Flags().BoolVar(&opts.enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	c.Flags().StringVar(&opts.electionID, "election-id", "ngrok-ingress-controller-leader", "The name of the configmap that is used for holding the leader lock")
 	c.Flags().StringVar(&opts.region, "region", "us", "The region to use for ngrok tunnels")
 	opts.zapOpts = &zap.Options{Development: true}
 	goFlagSet := flag.NewFlagSet("manager", flag.ContinueOnError)
@@ -111,8 +111,8 @@ func runController(ctx context.Context, opts managerOpts) error {
 		MetricsBindAddress:     opts.metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: opts.probeAddr,
-		LeaderElection:         true,
-		LeaderElectionID:       "ngrok-ingress-controller-leader",
+		LeaderElection:         opts.electionID != "",
+		LeaderElectionID:       opts.electionID,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start manager: %w", err)

--- a/helm/ingress-controller/CHANGELOG.md
+++ b/helm/ingress-controller/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0
+### Added
+
+- Support for different values commonly found in helm charts
+
 # 0.1.0
 
 TODO

--- a/helm/ingress-controller/Chart.yaml
+++ b/helm/ingress-controller/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ngrok-ingress-controller
 description: A Kubernetes ingress controller built using ngrok.
-version: 0.1.2
+version: 0.2.0
 appVersion: 0.1.0
 keywords:
   - ngrok

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -33,21 +33,36 @@ To uninstall the chart:
 <!-- Parameters are auto generated via @bitnami/readme-generator-for-helm -->
 ## Parameters
 
+### Common parameters
+
+| Name                | Description                                           | Value |
+| ------------------- | ----------------------------------------------------- | ----- |
+| `nameOverride`      | String to partially override generated resource names | `""`  |
+| `fullnameOverride`  | String to fully override generated resource names     | `""`  |
+| `commonLabels`      | Labels to add to all deployed objects                 | `{}`  |
+| `commonAnnotations` | Annotations to add to all deployed objects            | `{}`  |
+
+
 ### Controller parameters
 
-| Name                     | Description                                     | Value                                  |
-| ------------------------ | ----------------------------------------------- | -------------------------------------- |
-| `podAnnotations`         | Used to inject custom annotations directly into | `{}`                                   |
-| `replicaCount`           | The number of controllers and agents to run.    | `2`                                    |
-| `image.repository`       | The ngrok ingress controller image repository.  | `ngrok/ngrok-ingress-controller`       |
-| `image.tag`              | The ngrok ingress controller image tag.         | `latest`                               |
-| `image.pullPolicy`       | The ngrok ingress controller image pull policy. | `IfNotPresent`                         |
-| `ingressClass`           | The ingress class this controller will satisfy. | `ngrok`                                |
-| `log`                    | Agent log destination.                          | `stdout`                               |
-| `region`                 | ngrok region to create tunnels in.              | `us`                                   |
-| `credentialsSecret.name` | The name of the K8S secret that contains the    | `ngrok-ingress-controller-credentials` |
-| `apiKey`                 | The ngrok API key to use                        | `""`                                   |
-| `authtoken`              | The ngrok auth token to use                     | `""`                                   |
-| `resources.limits`       | The resources limits for the container          | `{}`                                   |
-| `resources.requests`     | The requested resources for the container       | `{}`                                   |
+| Name                         | Description                                                     | Value                                  |
+| ---------------------------- | --------------------------------------------------------------- | -------------------------------------- |
+| `podAnnotations`             | Used to inject custom annotations directly into                 | `{}`                                   |
+| `replicaCount`               | The number of controllers and agents to run.                    | `2`                                    |
+| `image.registry`             | The ngrok ingress controller image registry.                    | `docker.io`                            |
+| `image.repository`           | The ngrok ingress controller image repository.                  | `ngrok/ngrok-ingress-controller`       |
+| `image.tag`                  | The ngrok ingress controller image tag.                         | `latest`                               |
+| `image.pullPolicy`           | The ngrok ingress controller image pull policy.                 | `IfNotPresent`                         |
+| `image.pullSecrets`          | An array of imagePullSecrets to be used when pulling the image. | `[]`                                   |
+| `ingressClass`               | The ingress class this controller will satisfy.                 | `ngrok`                                |
+| `log`                        | Agent log destination.                                          | `stdout`                               |
+| `region`                     | ngrok region to create tunnels in.                              | `us`                                   |
+| `credentialsSecret.name`     | The name of the K8S secret that contains the                    | `ngrok-ingress-controller-credentials` |
+| `apiKey`                     | The ngrok API key to use                                        | `""`                                   |
+| `authtoken`                  | The ngrok auth token to use                                     | `""`                                   |
+| `resources.limits`           | The resources limits for the container                          | `{}`                                   |
+| `resources.requests`         | The requested resources for the container                       | `{}`                                   |
+| `serviceAccount.create`      | Specifies whether a ServiceAccount should be created            | `true`                                 |
+| `serviceAccount.name`        | The name of the ServiceAccount to use.                          | `""`                                   |
+| `serviceAccount.annotations` | Additional annotations to add to the ServiceAccount             | `{}`                                   |
 

--- a/helm/ingress-controller/README.md
+++ b/helm/ingress-controller/README.md
@@ -54,7 +54,9 @@ To uninstall the chart:
 | `image.tag`                  | The ngrok ingress controller image tag.                         | `latest`                               |
 | `image.pullPolicy`           | The ngrok ingress controller image pull policy.                 | `IfNotPresent`                         |
 | `image.pullSecrets`          | An array of imagePullSecrets to be used when pulling the image. | `[]`                                   |
-| `ingressClass`               | The ingress class this controller will satisfy.                 | `ngrok`                                |
+| `ingressClass.name`          | The name of the ingress class to use.                           | `ngrok`                                |
+| `ingressClass.create`        | Whether to create the ingress class.                            | `true`                                 |
+| `ingressClass.default`       | Whether to set the ingress class as default.                    | `true`                                 |
 | `log`                        | Agent log destination.                                          | `stdout`                               |
 | `region`                     | ngrok region to create tunnels in.                              | `us`                                   |
 | `credentialsSecret.name`     | The name of the K8S secret that contains the                    | `ngrok-ingress-controller-credentials` |

--- a/helm/ingress-controller/templates/_helpers.tpl
+++ b/helm/ingress-controller/templates/_helpers.tpl
@@ -64,3 +64,13 @@ Create the name of the controller service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the ngrok/ingress-controller image name
+*/}}
+{{- define "ngrok-ingress-controller.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}

--- a/helm/ingress-controller/templates/_helpers.tpl
+++ b/helm/ingress-controller/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ngrok-ingress-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ngrok-ingress-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "ngrok-ingress-controller.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ngrok-ingress-controller.labels" -}}
+helm.sh/chart: {{ include "ngrok-ingress-controller.chart" . }}
+{{ include "ngrok-ingress-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/part-of: {{ template "ngrok-ingress-controller.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ngrok-ingress-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ngrok-ingress-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "ngrok-ingress-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "ngrok-ingress-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/ingress-controller/templates/agent-config-cm.yaml
+++ b/helm/ingress-controller/templates/agent-config-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ngrok-ingress-controller-agent-cm
+  name: {{ include "ngrok-ingress-controller.fullname" . }}-agent-cm
   namespace: {{ .Release.Namespace }}
 data:
   LOG:  "{{ .Values.log }}"

--- a/helm/ingress-controller/templates/controller-cm.yaml
+++ b/helm/ingress-controller/templates/controller-cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ngrok-ingress-controller-manager-config
+  name: {{ include "ngrok-ingress-controller.fullname" . }}-manager-config
   namespace: {{ .Release.Namespace }}
 data:
   controller_manager_config.yaml: |
@@ -13,5 +13,4 @@ data:
       bindAddress: 127.0.0.1:8080
     leaderElection:
       leaderElect: true
-      resourceName: ngrok-ingress-controller-leader
-
+      resourceName: {{ include "ngrok-ingress-controller.fullname" . }}-leader

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
-        - --leader-elect
+        - --election-id={{ include "ngrok-ingress-controller.fullname" . }}-leader
         {{- if .Values.region }}
         - --region={{ .Values.region}}
         {{- end }}

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         - ./scripts/gen-agent-config.sh
         envFrom:
         - configMapRef:
-            name: ngrok-ingress-controller-agent-cm
+            name: {{ include "ngrok-ingress-controller.fullname" . }}-agent-cm
             optional: true
         env:
         - name: NGROK_AUTHTOKEN

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -2,8 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: ngrok-ingress-controller
-  name: ngrok-ingress-controller-manager
+    {{- include "ngrok-ingress-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  name: {{ include "ngrok-ingress-controller.fullname" . }}-manager
   namespace: {{ .Release.Namespace }}
   annotations:
     checksum/agent-config: {{ include (print $.Template.BasePath "/agent-config-cm.yaml") . | sha256sum }}
@@ -13,7 +14,8 @@ spec:
   replicas: {{.Values.replicaCount}}
   selector:
     matchLabels:
-      app: ngrok-ingress-controller
+      {{- include "ngrok-ingress-controller.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
   template:
     metadata:
       annotations:
@@ -25,7 +27,8 @@ spec:
         prometheus.io/port: '8080'
         prometheus.io/scrape: 'true'
       labels:
-        app: ngrok-ingress-controller
+        {{- include "ngrok-ingress-controller.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
       volumes:

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -31,6 +31,10 @@ spec:
         app.kubernetes.io/component: controller
     spec:
       serviceAccountName: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       volumes:
       - name: scripts
         configMap:
@@ -38,7 +42,7 @@ spec:
           defaultMode: 0755
       containers:
       - name: ngrok-ingress-controller
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ include "ngrok-ingress-controller.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /manager

--- a/helm/ingress-controller/templates/controller-deployment.yaml
+++ b/helm/ingress-controller/templates/controller-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       labels:
         app: ngrok-ingress-controller
     spec:
-      serviceAccountName: ngrok-ingress-controller-manager
+      serviceAccountName: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
       volumes:
       - name: scripts
         configMap:

--- a/helm/ingress-controller/templates/controller-rbac.yaml
+++ b/helm/ingress-controller/templates/controller-rbac.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ngrok-ingress-controller-manager
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -72,7 +66,7 @@ roleRef:
   name: ngrok-ingress-controller-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: ngrok-ingress-controller-manager
+  name: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -85,7 +79,7 @@ roleRef:
   name: ngrok-ingress-controller-manager-role
 subjects:
 - kind: ServiceAccount
-  name: ngrok-ingress-controller-manager
+  name: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -98,5 +92,5 @@ roleRef:
   name: ngrok-ingress-controller-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: ngrok-ingress-controller-manager
+  name: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm/ingress-controller/templates/controller-serviceaccount.yaml
+++ b/helm/ingress-controller/templates/controller-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "ngrok-ingress-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ngrok-ingress-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/ingress-controller/templates/ingress-class.yaml
+++ b/helm/ingress-controller/templates/ingress-class.yaml
@@ -1,6 +1,15 @@
+{{- if .Values.ingressClass.create -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  name: {{ .Values.ingressClass}}
+  labels:
+    {{- include "ngrok-ingress-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+  name: {{ .Values.ingressClass.name }}
+  {{- if .Values.ingressClass.default }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
 spec:
   controller: k8s.ngrok.com/ingress-controller
+{{- end}}

--- a/helm/ingress-controller/tests/__snapshot__/agent-config-cm_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/agent-config-cm_test.yaml.snap
@@ -1,0 +1,12 @@
+Should match snapshot:
+  1: |
+    apiVersion: v1
+    data:
+      LOG: stdout
+      METADATA: ""
+      REGION: us
+      REMOTE_MANAGEMENT: ""
+    kind: ConfigMap
+    metadata:
+      name: ngrok-ingress-controller-agent-cm
+      namespace: NAMESPACE

--- a/helm/ingress-controller/tests/__snapshot__/agent-config-cm_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/agent-config-cm_test.yaml.snap
@@ -8,5 +8,5 @@ Should match snapshot:
       REMOTE_MANAGEMENT: ""
     kind: ConfigMap
     metadata:
-      name: ngrok-ingress-controller-agent-cm
+      name: RELEASE-NAME-ngrok-ingress-controller-agent-cm
       namespace: NAMESPACE

--- a/helm/ingress-controller/tests/__snapshot__/controller-cm_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-cm_test.yaml.snap
@@ -1,0 +1,18 @@
+should match snapshot:
+  1: |
+    apiVersion: v1
+    data:
+      controller_manager_config.yaml: |
+        apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+        kind: ControllerManagerConfig
+        health:
+          healthProbeBindAddress: :8081
+        metrics:
+          bindAddress: 127.0.0.1:8080
+        leaderElection:
+          leaderElect: true
+          resourceName: ngrok-ingress-controller-leader
+    kind: ConfigMap
+    metadata:
+      name: ngrok-ingress-controller-manager-config
+      namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/controller-cm_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-cm_test.yaml.snap
@@ -11,8 +11,8 @@ should match snapshot:
           bindAddress: 127.0.0.1:8080
         leaderElection:
           leaderElect: true
-          resourceName: ngrok-ingress-controller-leader
+          resourceName: test-release-ngrok-ingress-controller-leader
     kind: ConfigMap
     metadata:
-      name: ngrok-ingress-controller-manager-config
+      name: test-release-ngrok-ingress-controller-manager-config
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -14,7 +14,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-ingress-controller
         app.kubernetes.io/part-of: ngrok-ingress-controller
         app.kubernetes.io/version: 0.1.0
-        helm.sh/chart: ngrok-ingress-controller-0.1.2
+        helm.sh/chart: ngrok-ingress-controller-0.2.0
       name: RELEASE-NAME-ngrok-ingress-controller-manager
       namespace: NAMESPACE
     spec:

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -30,7 +30,7 @@ Should match snapshot:
           - args:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
-            - --leader-elect
+            - --election-id=RELEASE-NAME-ngrok-ingress-controller-leader
             - --region=us
             command:
             - /manager

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -4,7 +4,7 @@ Should match snapshot:
     kind: Deployment
     metadata:
       annotations:
-        checksum/agent-config: 7f940449c596d0f38d8694cf3fbfc65a95feccfd4cdb5b6c1ebf13b88d7bac16
+        checksum/agent-config: c477ecc68a20d5571a24a33342f62893ed4c1d89ecb80cc7cf97b58b290e2891
         checksum/controller-role: 4c8da8ec4e728eb7bbf0e2f88f5ad55781f988247737d6f1c889c736aa909c60
         checksum/rbac: a680811929fbf29dce4d4818bf7fa3dd8ed258cb8f07daf7ce1f9d19093ff3da
       labels:
@@ -76,7 +76,7 @@ Should match snapshot:
               value: us
             envFrom:
             - configMapRef:
-                name: ngrok-ingress-controller-agent-cm
+                name: RELEASE-NAME-ngrok-ingress-controller-agent-cm
                 optional: true
             image: ngrok/ngrok:3
             name: ngrok-cli
@@ -124,7 +124,7 @@ Should match snapshot:
       REMOTE_MANAGEMENT: ""
     kind: ConfigMap
     metadata:
-      name: ngrok-ingress-controller-agent-cm
+      name: RELEASE-NAME-ngrok-ingress-controller-agent-cm
       namespace: NAMESPACE
   4: |
     apiVersion: v1

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -1,0 +1,289 @@
+Should match snapshot:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        checksum/agent-config: 7f940449c596d0f38d8694cf3fbfc65a95feccfd4cdb5b6c1ebf13b88d7bac16
+        checksum/controller-role: 4c8da8ec4e728eb7bbf0e2f88f5ad55781f988247737d6f1c889c736aa909c60
+        checksum/rbac: a680811929fbf29dce4d4818bf7fa3dd8ed258cb8f07daf7ce1f9d19093ff3da
+      labels:
+        app: ngrok-ingress-controller
+      name: ngrok-ingress-controller-manager
+      namespace: NAMESPACE
+    spec:
+      replicas: 2
+      selector:
+        matchLabels:
+          app: ngrok-ingress-controller
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: manager
+            prometheus.io/path: /metrics
+            prometheus.io/port: "8080"
+            prometheus.io/scrape: "true"
+          labels:
+            app: ngrok-ingress-controller
+        spec:
+          containers:
+          - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8080
+            - --leader-elect
+            - --region=us
+            command:
+            - /manager
+            env:
+            - name: NGROK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_KEY
+                  name: ngrok-ingress-controller-credentials
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: ngrok/ngrok-ingress-controller:latest
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              httpGet:
+                path: /healthz
+                port: 8081
+              initialDelaySeconds: 15
+              periodSeconds: 20
+            name: ngrok-ingress-controller
+            readinessProbe:
+              httpGet:
+                path: /readyz
+                port: 8081
+              initialDelaySeconds: 5
+              periodSeconds: 10
+            resources:
+              limits: {}
+              requests: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+          - command:
+            - ./scripts/gen-agent-config.sh
+            env:
+            - name: NGROK_AUTHTOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: AUTHTOKEN
+                  name: ngrok-ingress-controller-credentials
+            - name: NGROK_REGION
+              value: us
+            envFrom:
+            - configMapRef:
+                name: ngrok-ingress-controller-agent-cm
+                optional: true
+            image: ngrok/ngrok:3
+            name: ngrok-cli
+            volumeMounts:
+            - mountPath: /scripts
+              name: scripts
+              readOnly: true
+          serviceAccountName: ngrok-ingress-controller-manager
+          volumes:
+          - configMap:
+              defaultMode: 493
+              name: scripts
+            name: scripts
+  2: |
+    apiVersion: v1
+    data:
+      gen-agent-config.sh: |
+        #!/bin/bash
+
+        NGROK_LOG="${NGROK_LOG:-stdout}"
+        NGROK_REGION="${NGROK_REGION:-us}"
+        NGROK_REMOTE_MANAGEMENT="${NGROK_REMOTE_MANAGEMENT:-true}"
+
+        cat > /var/lib/ngrok/agent-template.yaml <<EOF
+        version: 2
+        authtoken: $NGROK_AUTHTOKEN
+        console_ui: false
+        log: $NGROK_LOG
+        region: $NGROK_REGION
+        remote_management: $NGROK_REMOTE_MANAGEMENT
+        update_check: false
+        EOF
+
+        ngrok start --none --config /var/lib/ngrok/agent-template.yaml
+    kind: ConfigMap
+    metadata:
+      name: scripts
+      namespace: NAMESPACE
+  3: |
+    apiVersion: v1
+    data:
+      LOG: stdout
+      METADATA: ""
+      REGION: us
+      REMOTE_MANAGEMENT: ""
+    kind: ConfigMap
+    metadata:
+      name: ngrok-ingress-controller-agent-cm
+      namespace: NAMESPACE
+  4: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: ngrok-ingress-controller-manager
+      namespace: NAMESPACE
+  5: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: ngrok-ingress-controller-leader-election-role
+      namespace: NAMESPACE
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+  6: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: ngrok-ingress-controller-proxy-role
+    rules:
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+  7: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: ngrok-ingress-controller-leader-election-rolebinding
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ngrok-ingress-controller-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: ngrok-ingress-controller-manager
+      namespace: NAMESPACE
+  8: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: ngrok-ingress-controller-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ngrok-ingress-controller-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: ngrok-ingress-controller-manager
+      namespace: NAMESPACE
+  9: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: ngrok-ingress-controller-proxy-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ngrok-ingress-controller-proxy-role
+    subjects:
+    - kind: ServiceAccount
+      name: ngrok-ingress-controller-manager
+      namespace: NAMESPACE
+  10: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: ngrok-ingress-controller-manager-role
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingressclasses
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses
+      verbs:
+      - get
+      - list
+      - update
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses/status
+      verbs:
+      - get
+      - list
+      - update
+      - watch

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -8,14 +8,22 @@ Should match snapshot:
         checksum/controller-role: 4c8da8ec4e728eb7bbf0e2f88f5ad55781f988247737d6f1c889c736aa909c60
         checksum/rbac: d65fd1d397f0da2dc2888c7af42265b5a47272fbbf56a0c3331023d949f3c58b
       labels:
-        app: ngrok-ingress-controller
-      name: ngrok-ingress-controller-manager
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ngrok-ingress-controller
+        app.kubernetes.io/part-of: ngrok-ingress-controller
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: ngrok-ingress-controller-0.1.2
+      name: RELEASE-NAME-ngrok-ingress-controller-manager
       namespace: NAMESPACE
     spec:
       replicas: 2
       selector:
         matchLabels:
-          app: ngrok-ingress-controller
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: ngrok-ingress-controller
       template:
         metadata:
           annotations:
@@ -24,7 +32,9 @@ Should match snapshot:
             prometheus.io/port: "8080"
             prometheus.io/scrape: "true"
           labels:
-            app: ngrok-ingress-controller
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: ngrok-ingress-controller
         spec:
           containers:
           - args:
@@ -84,7 +94,7 @@ Should match snapshot:
             - mountPath: /scripts
               name: scripts
               readOnly: true
-          serviceAccountName: ngrok-ingress-controller-manager
+          serviceAccountName: RELEASE-NAME-ngrok-ingress-controller
           volumes:
           - configMap:
               defaultMode: 493

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -6,7 +6,7 @@ Should match snapshot:
       annotations:
         checksum/agent-config: c477ecc68a20d5571a24a33342f62893ed4c1d89ecb80cc7cf97b58b290e2891
         checksum/controller-role: 4c8da8ec4e728eb7bbf0e2f88f5ad55781f988247737d6f1c889c736aa909c60
-        checksum/rbac: a680811929fbf29dce4d4818bf7fa3dd8ed258cb8f07daf7ce1f9d19093ff3da
+        checksum/rbac: d65fd1d397f0da2dc2888c7af42265b5a47272fbbf56a0c3331023d949f3c58b
       labels:
         app: ngrok-ingress-controller
       name: ngrok-ingress-controller-manager
@@ -127,12 +127,6 @@ Should match snapshot:
       name: RELEASE-NAME-ngrok-ingress-controller-agent-cm
       namespace: NAMESPACE
   4: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: ngrok-ingress-controller-manager
-      namespace: NAMESPACE
-  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -170,7 +164,7 @@ Should match snapshot:
       verbs:
       - create
       - patch
-  6: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -188,7 +182,7 @@ Should match snapshot:
       - subjectaccessreviews
       verbs:
       - create
-  7: |
+  6: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -200,9 +194,9 @@ Should match snapshot:
       name: ngrok-ingress-controller-leader-election-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE
-  8: |
+  7: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -213,9 +207,9 @@ Should match snapshot:
       name: ngrok-ingress-controller-manager-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE
-  9: |
+  8: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -226,9 +220,9 @@ Should match snapshot:
       name: ngrok-ingress-controller-proxy-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE
-  10: |
+  9: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -54,7 +54,7 @@ Should match snapshot:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: ngrok/ngrok-ingress-controller:latest
+            image: docker.io/ngrok/ngrok-ingress-controller:latest
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:

--- a/helm/ingress-controller/tests/__snapshot__/controller-rbac_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-rbac_test.yaml.snap
@@ -1,11 +1,5 @@
 Should match snapshot:
   1: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: ngrok-ingress-controller-manager
-      namespace: NAMESPACE
-  2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
@@ -43,7 +37,7 @@ Should match snapshot:
       verbs:
       - create
       - patch
-  3: |
+  2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -61,7 +55,7 @@ Should match snapshot:
       - subjectaccessreviews
       verbs:
       - create
-  4: |
+  3: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
@@ -73,9 +67,9 @@ Should match snapshot:
       name: ngrok-ingress-controller-leader-election-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE
-  5: |
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -86,9 +80,9 @@ Should match snapshot:
       name: ngrok-ingress-controller-manager-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE
-  6: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -99,5 +93,5 @@ Should match snapshot:
       name: ngrok-ingress-controller-proxy-role
     subjects:
     - kind: ServiceAccount
-      name: ngrok-ingress-controller-manager
+      name: RELEASE-NAME-ngrok-ingress-controller
       namespace: NAMESPACE

--- a/helm/ingress-controller/tests/__snapshot__/controller-rbac_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-rbac_test.yaml.snap
@@ -1,4 +1,4 @@
-Should generate rbac:
+Should match snapshot:
   1: |
     apiVersion: v1
     kind: ServiceAccount

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -1,0 +1,15 @@
+Should match the snapshot:
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ngrok-ingress-controller
+        app.kubernetes.io/part-of: ngrok-ingress-controller
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: ngrok-ingress-controller-0.1.2
+      name: test-release-ngrok-ingress-controller
+      namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-serviceaccount_test.yaml.snap
@@ -10,6 +10,6 @@ Should match the snapshot:
         app.kubernetes.io/name: ngrok-ingress-controller
         app.kubernetes.io/part-of: ngrok-ingress-controller
         app.kubernetes.io/version: 0.1.0
-        helm.sh/chart: ngrok-ingress-controller-0.1.2
+        helm.sh/chart: ngrok-ingress-controller-0.2.0
       name: test-release-ngrok-ingress-controller
       namespace: test-namespace

--- a/helm/ingress-controller/tests/__snapshot__/credentials-secret_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/credentials-secret_test.yaml.snap
@@ -1,0 +1,10 @@
+Should match snapshot:
+  1: |
+    apiVersion: v1
+    data:
+      API_KEY: dGVzdC1hcGkta2V5
+      AUTHTOKEN: dGVzdC1hdXRodG9rZW4=
+    kind: Secret
+    metadata:
+      name: ngrok-ingress-controller-credentials
+    type: Opaque

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -3,6 +3,16 @@ Should match snapshot:
     apiVersion: networking.k8s.io/v1
     kind: IngressClass
     metadata:
+      annotations:
+        ingressclass.kubernetes.io/is-default-class: "true"
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ngrok-ingress-controller
+        app.kubernetes.io/part-of: ngrok-ingress-controller
+        app.kubernetes.io/version: 0.1.0
+        helm.sh/chart: ngrok-ingress-controller-0.1.2
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -12,7 +12,7 @@ Should match snapshot:
         app.kubernetes.io/name: ngrok-ingress-controller
         app.kubernetes.io/part-of: ngrok-ingress-controller
         app.kubernetes.io/version: 0.1.0
-        helm.sh/chart: ngrok-ingress-controller-0.1.2
+        helm.sh/chart: ngrok-ingress-controller-0.2.0
       name: ngrok
     spec:
       controller: k8s.ngrok.com/ingress-controller

--- a/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/ingress-class_test.yaml.snap
@@ -1,0 +1,8 @@
+Should match snapshot:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: ngrok
+    spec:
+      controller: k8s.ngrok.com/ingress-controller

--- a/helm/ingress-controller/tests/agent-config-cm_test.yaml
+++ b/helm/ingress-controller/tests/agent-config-cm_test.yaml
@@ -1,0 +1,7 @@
+suite: test agent-config-cm
+templates:
+- agent-config-cm.yaml
+tests:
+- it: Should match snapshot
+  asserts:
+  - matchSnapshot: {}

--- a/helm/ingress-controller/tests/controller-cm_test.yaml
+++ b/helm/ingress-controller/tests/controller-cm_test.yaml
@@ -5,6 +5,9 @@ release:
   name: test-release
   namespace: test-namespace
 tests:
+- it: should match snapshot
+  asserts:
+  - matchSnapshot: {}
 - it: should create a configmap
   asserts:
   - isKind:

--- a/helm/ingress-controller/tests/controller-cm_test.yaml
+++ b/helm/ingress-controller/tests/controller-cm_test.yaml
@@ -27,4 +27,11 @@ tests:
   asserts:
   - equal:
       path: metadata.name
-      value: ngrok-ingress-controller-manager-config
+      value: test-release-ngrok-ingress-controller-manager-config
+- it: Works when fullname is supplied
+  set:
+    fullnameOverride: fno
+  asserts:
+  - equal:
+      path: metadata.name
+      value: fno-manager-config

--- a/helm/ingress-controller/tests/controller-deployment_test.yaml
+++ b/helm/ingress-controller/tests/controller-deployment_test.yaml
@@ -1,0 +1,15 @@
+suite: test controller-deployment
+templates:
+- controller-deployment.yaml
+# The following included templates are needed due to the way helm unittest works.
+# It won't load the temaplates unless they are included here. Due to the checksums
+# we are including on the deployment, we need to include them here. It makes the
+# snapshot much larger than it needs to be, but it's the only way to test the
+# deployment at this time.
+- agent-config-cm.yaml
+- controller-rbac.yaml
+- role.yaml
+tests:
+- it: Should match snapshot
+  asserts:
+  - matchSnapshot: {}

--- a/helm/ingress-controller/tests/controller-rbac_test.yaml
+++ b/helm/ingress-controller/tests/controller-rbac_test.yaml
@@ -2,6 +2,6 @@ suite: test controller-rbac
 templates:
 - controller-rbac.yaml
 tests:
-- it: Should generate rbac
+- it: Should match snapshot
   asserts:
   - matchSnapshot: {}

--- a/helm/ingress-controller/tests/controller-serviceaccount_test.yaml
+++ b/helm/ingress-controller/tests/controller-serviceaccount_test.yaml
@@ -1,0 +1,24 @@
+suite: test controller-serviceaccount
+templates:
+- controller-serviceaccount.yaml
+release:
+  name: test-release
+  namespace: test-namespace
+tests:
+- it: should create a serviceaccount
+  asserts:
+  - isKind:
+      of: ServiceAccount
+  - isAPIVersion:
+      of: v1
+  - hasDocuments:
+      count: 1
+- it: does not generate a serviceaccount when serviceAccount.create is false
+  set:
+    serviceAccount.create: false
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: Should match the snapshot
+  asserts:
+  - matchSnapshot: {}

--- a/helm/ingress-controller/tests/credentials-secret_test.yaml
+++ b/helm/ingress-controller/tests/credentials-secret_test.yaml
@@ -1,0 +1,10 @@
+suite: test credentials-secret
+templates:
+- credentials-secret.yaml
+tests:
+- it: Should match snapshot
+  set:
+    apiKey: "test-api-key"
+    authtoken: "test-authtoken"
+  asserts:
+  - matchSnapshot: {}

--- a/helm/ingress-controller/tests/ingress-class_test.yaml
+++ b/helm/ingress-controller/tests/ingress-class_test.yaml
@@ -1,0 +1,7 @@
+suite: test ingress-class
+templates:
+- ingress-class.yaml
+tests:
+- it: Should match snapshot
+  asserts:
+  - matchSnapshot: {}

--- a/helm/ingress-controller/tests/ingress-class_test.yaml
+++ b/helm/ingress-controller/tests/ingress-class_test.yaml
@@ -5,3 +5,15 @@ tests:
 - it: Should match snapshot
   asserts:
   - matchSnapshot: {}
+- it: Creates an default ingress class called ngrok by default
+  asserts:
+  - isKind:
+      of: IngressClass
+  - hasDocuments:
+      count: 1
+- it: Does not create an ingress class when ingressClass.create is false
+  set:
+    ingressClass.create: false
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -36,10 +36,13 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
-## @param ingressClass The ingress class this controller will satisfy.
-## If not specified, controller will match all ingresses without ingress
-## class annotation and ingresses of type ngrok
-ingressClass: ngrok
+## @param ingressClass.name The name of the ingress class to use.
+## @param ingressClass.create Whether to create the ingress class.
+## @param ingressClass.default Whether to set the ingress class as default.
+ingressClass:
+  name: ngrok
+  create: true
+  default: true
 
 ## @param log Agent log destination.
 log: stdout

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -1,3 +1,16 @@
+## @section Common parameters
+##
+
+## @param nameOverride String to partially override generated resource names
+## @param fullnameOverride String to fully override generated resource names
+## @param commonLabels Labels to add to all deployed objects
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+commonAnnotations: {}
+
 ## @section Controller parameters
 ##
 
@@ -11,13 +24,17 @@ podAnnotations: {}
 ##
 replicaCount: 2
 
+## @param image.registry The ngrok ingress controller image registry.
 ## @param image.repository The ngrok ingress controller image repository.
 ## @param image.tag The ngrok ingress controller image tag.
 ## @param image.pullPolicy The ngrok ingress controller image pull policy.
+## @param image.pullSecrets An array of imagePullSecrets to be used when pulling the image.
 image:
+  registry: docker.io
   repository: ngrok/ngrok-ingress-controller
   tag: latest
   pullPolicy: IfNotPresent
+  pullSecrets: []
 
 ## @param ingressClass The ingress class this controller will satisfy.
 ## If not specified, controller will match all ingresses without ingress
@@ -61,3 +78,15 @@ resources:
   ##    memory: 128Mi
   ##
   requests: {}
+
+
+## Controller Service Account Settings
+## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+## @param serviceAccount.name The name of the ServiceAccount to use.
+## If not set and create is true, a name is generated using the fullname template
+## @param serviceAccount.annotations Additional annotations to add to the ServiceAccount
+##
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}

--- a/helm/ingress-controller/values.yaml
+++ b/helm/ingress-controller/values.yaml
@@ -34,6 +34,10 @@ image:
   repository: ngrok/ngrok-ingress-controller
   tag: latest
   pullPolicy: IfNotPresent
+  ## Example
+  ## pullSecrets:
+  ## - name: my-imagepull-secret
+  ##
   pullSecrets: []
 
 ## @param ingressClass.name The name of the ingress class to use.


### PR DESCRIPTION
Resolves: #55 

## What

Adding more helm common values like overriding the `image.registry` and adding `image.pullSecrets`. See changes in the `values.yaml` file.

## How

* Added additional helm template snapshots for future testing. About half of this PR are tests.
* Updated the command line args of the controller to support taking an `election-id` since we support overriding the name now that is used to prefix resources.


## Breaking Changes
Yes, specifically the names of resources are now prefixed to support overriding with `nameOverride` and `fullnameOverride` as is common in a lot of helm charts.