### PR TITLE
Add TCPEdge Controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230103223931-056869c967cd
 	sigs.k8s.io/controller-tools v0.11.1
@@ -95,7 +96,6 @@ require (
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221207184640-f3cff1453715 // indirect
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/cmd/config v0.10.9 // indirect

--- a/helm/ingress-controller/templates/rbac/role.yaml
+++ b/helm/ingress-controller/templates/rbac/role.yaml
@@ -60,6 +60,32 @@ rules:
 - apiGroups:
   - ingress.k8s.ngrok.com
   resources:
+  - tcpedges
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ingress.k8s.ngrok.com
+  resources:
+  - tcpedges/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ingress.k8s.ngrok.com
+  resources:
+  - tcpedges/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ingress.k8s.ngrok.com
+  resources:
   - tunnels
   verbs:
   - create

--- a/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
+++ b/helm/ingress-controller/tests/__snapshot__/controller-deployment_test.yaml.snap
@@ -5,7 +5,7 @@ Should match all-options snapshot:
     metadata:
       annotations:
         checksum/agent-config: 3671fa6e906913b7e88c956cd85864fb4a056335e2676f8fce44a1cfafba37d6
-        checksum/controller-role: 175dc8ea9d6eede9b368731c6fc8078c54e497102a8ec5ee08d08f0ae0c991c5
+        checksum/controller-role: 75223d0b5fbf175b0112a0d76e427f5c42d76b37931d8c455450a87638d6b5bd
         checksum/rbac: d65fd1d397f0da2dc2888c7af42265b5a47272fbbf56a0c3331023d949f3c58b
       labels:
         app.kubernetes.io/component: controller
@@ -260,6 +260,32 @@ Should match all-options snapshot:
     - apiGroups:
       - ingress.k8s.ngrok.com
       resources:
+      - tcpedges
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
+      - tcpedges/finalizers
+      verbs:
+      - update
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
+      - tcpedges/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
       - tunnels
       verbs:
       - create
@@ -316,7 +342,7 @@ Should match default snapshot:
     metadata:
       annotations:
         checksum/agent-config: 3671fa6e906913b7e88c956cd85864fb4a056335e2676f8fce44a1cfafba37d6
-        checksum/controller-role: 175dc8ea9d6eede9b368731c6fc8078c54e497102a8ec5ee08d08f0ae0c991c5
+        checksum/controller-role: 75223d0b5fbf175b0112a0d76e427f5c42d76b37931d8c455450a87638d6b5bd
         checksum/rbac: d65fd1d397f0da2dc2888c7af42265b5a47272fbbf56a0c3331023d949f3c58b
       labels:
         app.kubernetes.io/component: controller
@@ -551,6 +577,32 @@ Should match default snapshot:
       - ingress.k8s.ngrok.com
       resources:
       - domains/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
+      - tcpedges
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
+      - tcpedges/finalizers
+      verbs:
+      - update
+    - apiGroups:
+      - ingress.k8s.ngrok.com
+      resources:
+      - tcpedges/status
       verbs:
       - get
       - patch

--- a/internal/controllers/tcpedge_controller.go
+++ b/internal/controllers/tcpedge_controller.go
@@ -1,0 +1,221 @@
+/*
+MIT License
+
+Copyright (c) 2022 ngrok, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	"github.com/ngrok/ngrok-api-go/v5"
+	"github.com/ngrok/ngrok-api-go/v5/backends/tunnel_group"
+	"github.com/ngrok/ngrok-api-go/v5/edges/tcp"
+	ingressv1alpha1 "github.com/ngrok/ngrok-ingress-controller/api/v1alpha1"
+)
+
+// TCPEdgeReconciler reconciles a TCPEdge object
+type TCPEdgeReconciler struct {
+	client.Client
+
+	Log      logr.Logger
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	TCPEdgeClient            *tcp.Client
+	TunnelGroupBackendClient *tunnel_group.Client
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TCPEdgeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&ingressv1alpha1.TCPEdge{}).
+		Complete(r)
+}
+
+//+kubebuilder:rbac:groups=ingress.k8s.ngrok.com,resources=tcpedges,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ingress.k8s.ngrok.com,resources=tcpedges/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ingress.k8s.ngrok.com,resources=tcpedges/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.1/pkg/reconcile
+func (r *TCPEdgeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("V1Alpha1TCPEdge", req.NamespacedName)
+
+	edge := new(ingressv1alpha1.TCPEdge)
+	if err := r.Get(ctx, req.NamespacedName, edge); err != nil {
+		log.Error(err, "unable to fetch Edge")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if edge == nil {
+		return ctrl.Result{}, nil
+	}
+
+	if edge.ObjectMeta.DeletionTimestamp.IsZero() {
+		if err := registerAndSyncFinalizer(ctx, r.Client, edge); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
+		// The object is being deleted
+		if hasFinalizer(edge) {
+			if edge.Status.ID != "" {
+				r.Recorder.Event(edge, v1.EventTypeNormal, "Deleting", fmt.Sprintf("Deleting Edge %s", edge.Name))
+				if err := r.TCPEdgeClient.Delete(ctx, edge.Status.ID); err != nil {
+					if !ngrok.IsNotFound(err) {
+						r.Recorder.Event(edge, v1.EventTypeWarning, "FailedDelete", fmt.Sprintf("Failed to delete Edge %s: %s", edge.Name, err.Error()))
+						return ctrl.Result{}, err
+					}
+				}
+				edge.Status.ID = ""
+			}
+
+			if err := removeAndSyncFinalizer(ctx, r.Client, edge); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		r.Recorder.Event(edge, v1.EventTypeNormal, "Deleted", fmt.Sprintf("Deleted Edge %s", edge.Name))
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.reconcileTunnelGroupBackend(ctx, edge); err != nil {
+		log.Error(err, "unable to ensure tunnel group backend", err.Error())
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, r.reconcileEdge(ctx, edge)
+}
+
+func (r *TCPEdgeReconciler) reconcileTunnelGroupBackend(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
+	specBackend := edge.Spec.Backend
+	// First make sure the tunnel group backend matches
+	if edge.Status.Backend.ID != "" {
+		// A backend has already been created for this edge, make sure the labels match
+		backend, err := r.TunnelGroupBackendClient.Get(ctx, edge.Status.Backend.ID)
+		if err != nil {
+			return err
+		}
+
+		// If the labels don't match, update the backend with the desired labels
+		if !reflect.DeepEqual(backend.Labels, specBackend.Labels) {
+			backend, err = r.TunnelGroupBackendClient.Update(ctx, &ngrok.TunnelGroupBackendUpdate{
+				ID:          backend.ID,
+				Metadata:    pointer.String(specBackend.Metadata),
+				Description: pointer.String(specBackend.Description),
+				Labels:      specBackend.Labels,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// No backend has been created for this edge, create one
+	backend, err := r.TunnelGroupBackendClient.Create(ctx, &ngrok.TunnelGroupBackendCreate{
+		Metadata:    edge.Spec.Backend.Metadata,
+		Description: edge.Spec.Backend.Description,
+		Labels:      edge.Spec.Backend.Labels,
+	})
+	if err != nil {
+		return err
+	}
+	edge.Status.Backend.ID = backend.ID
+
+	return r.Status().Update(ctx, edge)
+}
+
+func (r *TCPEdgeReconciler) reconcileEdge(ctx context.Context, edge *ingressv1alpha1.TCPEdge) error {
+	if edge.Status.ID != "" {
+		// An edge already exists, make sure everything matches
+		resp, err := r.TCPEdgeClient.Get(ctx, edge.Status.ID)
+		if err != nil {
+			return err
+		}
+
+		// If the backend doesn't match, update the edge with the desired backend
+
+		if resp.Backend.Backend.ID != edge.Status.Backend.ID {
+			resp, err = r.TCPEdgeClient.Update(ctx, &ngrok.TCPEdgeUpdate{
+				ID:          resp.ID,
+				Description: pointer.String(edge.Spec.Description),
+				Metadata:    pointer.String(edge.Spec.Metadata),
+				Hostports:   edge.Status.Hostports,
+				Backend: &ngrok.EndpointBackendMutate{
+					BackendID: edge.Status.Backend.ID,
+				},
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		edge.Status.ID = resp.ID
+		edge.Status.URI = resp.URI
+		edge.Status.Hostports = resp.Hostports
+		edge.Status.Backend.ID = resp.Backend.Backend.ID
+		return r.Status().Update(ctx, edge)
+	}
+
+	// No edge has been created for this edge, create one
+	resp, err := r.TCPEdgeClient.Create(ctx, &ngrok.TCPEdgeCreate{
+		Description: edge.Spec.Description,
+		Metadata:    edge.Spec.Metadata,
+		Backend: &ngrok.EndpointBackendMutate{
+			BackendID: edge.Status.Backend.ID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	edge.Status.ID = resp.ID
+	edge.Status.URI = resp.URI
+	edge.Status.Hostports = resp.Hostports
+	edge.Status.Backend.ID = resp.Backend.Backend.ID
+	return r.Status().Update(ctx, edge)
+}
+
+func (r *TCPEdgeReconciler) findEdgeByHostports(ctx context.Context, hostports []string) (*ngrok.TCPEdge, error) {
+	iter := r.TCPEdgeClient.List(&ngrok.Paging{})
+	for iter.Next(ctx) {
+		edge := iter.Item()
+		if reflect.DeepEqual(edge.Hostports, hostports) {
+			return edge, nil
+		}
+	}
+	return nil, iter.Err()
+}

--- a/internal/controllers/utils.go
+++ b/internal/controllers/utils.go
@@ -37,3 +37,8 @@ func registerAndSyncFinalizer(ctx context.Context, c client.Writer, o client.Obj
 	}
 	return nil
 }
+
+func removeAndSyncFinalizer(ctx context.Context, c client.Writer, o client.Object) error {
+	removeFinalizer(o)
+	return c.Update(ctx, o)
+}

--- a/internal/ngrokapi/clientset.go
+++ b/internal/ngrokapi/clientset.go
@@ -1,0 +1,56 @@
+package ngrokapi
+
+import (
+	"github.com/ngrok/ngrok-api-go/v5"
+	tunnel_group_backends "github.com/ngrok/ngrok-api-go/v5/backends/tunnel_group"
+	https_edges "github.com/ngrok/ngrok-api-go/v5/edges/https"
+	https_edge_routes "github.com/ngrok/ngrok-api-go/v5/edges/https_routes"
+	tcp_edges "github.com/ngrok/ngrok-api-go/v5/edges/tcp"
+	"github.com/ngrok/ngrok-api-go/v5/reserved_domains"
+)
+
+type CLientset interface {
+	Domains() *reserved_domains.Client
+	HTTPSEdges() *https_edges.Client
+	HTTPSEdgeRoutes() *https_edge_routes.Client
+	TCPEdges() *tcp_edges.Client
+	TunnelGroupBackends() *tunnel_group_backends.Client
+}
+
+type DefaultClientset struct {
+	domainsClient             *reserved_domains.Client
+	httpsEdgesClient          *https_edges.Client
+	httpsEdgeRoutesClient     *https_edge_routes.Client
+	tcpEdgesClient            *tcp_edges.Client
+	tunnelGroupBackendsClient *tunnel_group_backends.Client
+}
+
+func NewClientSet(config *ngrok.ClientConfig) *DefaultClientset {
+	return &DefaultClientset{
+		domainsClient:             reserved_domains.NewClient(config),
+		httpsEdgesClient:          https_edges.NewClient(config),
+		httpsEdgeRoutesClient:     https_edge_routes.NewClient(config),
+		tcpEdgesClient:            tcp_edges.NewClient(config),
+		tunnelGroupBackendsClient: tunnel_group_backends.NewClient(config),
+	}
+}
+
+func (c *DefaultClientset) Domains() *reserved_domains.Client {
+	return c.domainsClient
+}
+
+func (c *DefaultClientset) HTTPSEdges() *https_edges.Client {
+	return c.httpsEdgesClient
+}
+
+func (c *DefaultClientset) HTTPSEdgeRoutes() *https_edge_routes.Client {
+	return c.httpsEdgeRoutesClient
+}
+
+func (c *DefaultClientset) TCPEdges() *tcp_edges.Client {
+	return c.tcpEdgesClient
+}
+
+func (c *DefaultClientset) TunnelGroupBackends() *tunnel_group_backends.Client {
+	return c.tunnelGroupBackendsClient
+}


### PR DESCRIPTION
## What

Add initial `TCPEdge` controller implementation for reconciling `TCPEdges`. Also add a ngrok API Clientset to make it easier to configure all of the clients and reference them in an easy way.

## How

While not directly exposed via the ingress controller, this allows for basic setup of TCP Edges backed by a labeled tunnel group like so

```yaml
---
kind: TCPEdge
apiVersion: ingress.k8s.ngrok.com/v1alpha1
metadata:
  name: starwars-edge
  namespace: default
spec:
  backend:
    labels:
      k8s.ngrok.com/namespace: default
      k8s.ngrok.com/service: starwars
      k8s.ngrok.com/port: "23"
---
kind: Tunnel
apiVersion: ingress.k8s.ngrok.com/v1alpha1
metadata:
  name: starwars-tunnel
  namespace: default
spec:
  forwardsTo: starwars.default.svc.cluster.local:23
  labels:
    k8s.ngrok.com/namespace: default
    k8s.ngrok.com/service: starwars
    k8s.ngrok.com/port: "23"
```

You can then run:

```
 kubectl -n default get tcpedges.ingress.k8s.ngrok.com                                                                                                                                                         
NAME            ID                                   HOSTPORTS                  BACKEND ID                          AGE
starwars-edge   edgtcp_2K2UAhHfG81<redacted>   ["1.tcp.ngrok.io:26439"]   bkdtg_2K2Qi5mDM<redacted>
```

and use the provided Hostport to access your service

## Breaking Changes

No